### PR TITLE
MVP Version 3 with Chainlink Mocked

### DIFF
--- a/packages/hardhat/deploy/00_deploy_your_contract.ts
+++ b/packages/hardhat/deploy/00_deploy_your_contract.ts
@@ -24,7 +24,7 @@ const deployYourContract: DeployFunction = async function (hre: HardhatRuntimeEn
   await deploy("YourContract", {
     from: deployer,
     // Contract constructor arguments
-    args: [deployer],
+    args: [deployer, 10],
     log: true,
     // autoMine: can be passed to the deploy function to make the deployment process faster on local networks by
     // automatically mining the contract deployment transaction. There is no effect on live networks.

--- a/packages/hardhat/test/YourContract.ts
+++ b/packages/hardhat/test/YourContract.ts
@@ -60,16 +60,16 @@ describe("YourContract", function () {
         // Send user's signed content item hash to the contract
         const signedContentItemHashFromUser = await user.signMessage(ethers.utils.arrayify(contentItemHash));
         await yourContract.connect(owner).userAction(user.address, contentItemHash, signedContentItemHashFromUser);
-        expect(await yourContract.userReadCounter(user.address)).to.equal(1);
+        expect(await yourContract.points(user.address)).to.equal(1);
 
         // Send otherUser's signed content item hash to the contract
         const signedContentItemHashFromOtherUser = await otherUser.signMessage(ethers.utils.arrayify(contentItemHash));
         await yourContract
           .connect(owner)
           .userAction(otherUser.address, contentItemHash, signedContentItemHashFromOtherUser);
-        expect(await yourContract.userReadCounter(otherUser.address)).to.equal(1);
+        expect(await yourContract.points(otherUser.address)).to.equal(1);
 
-        expect(await yourContract.readCounter()).to.equal(2);
+        expect(await yourContract.totalPoints()).to.equal(2);
       });
 
       it("Should emit ContentItemConsumed event", async function () {

--- a/packages/nextjs/contracts/deployedContracts.ts
+++ b/packages/nextjs/contracts/deployedContracts.ts
@@ -7,7 +7,7 @@ import { GenericContractsDeclaration } from "~~/utils/scaffold-eth/contract";
 const deployedContracts = {
   31337: {
     YourContract: {
-      address: "0xa85233C63b9Ee964Add6F2cffe00Fd84eb32338f",
+      address: "0x84eA74d481Ee0A5332c457a4d796187F6Ba67fEB",
       abi: [
         {
           inputs: [
@@ -15,6 +15,11 @@ const deployedContracts = {
               internalType: "address",
               name: "_owner",
               type: "address",
+            },
+            {
+              internalType: "uint256",
+              name: "_proposalReward",
+              type: "uint256",
             },
           ],
           stateMutability: "nonpayable",
@@ -80,6 +85,50 @@ const deployedContracts = {
           anonymous: false,
           inputs: [
             {
+              indexed: false,
+              internalType: "uint256",
+              name: "_proposalReward",
+              type: "uint256",
+            },
+          ],
+          name: "ProposalRewardChanged",
+          type: "event",
+        },
+        {
+          anonymous: false,
+          inputs: [
+            {
+              indexed: true,
+              internalType: "address",
+              name: "_proposer",
+              type: "address",
+            },
+            {
+              indexed: true,
+              internalType: "bytes32",
+              name: "_contentItemHash",
+              type: "bytes32",
+            },
+            {
+              indexed: false,
+              internalType: "uint256",
+              name: "_proposalReward",
+              type: "uint256",
+            },
+            {
+              indexed: false,
+              internalType: "uint256",
+              name: "_totalProposerPoints",
+              type: "uint256",
+            },
+          ],
+          name: "ValidProposalRewarded",
+          type: "event",
+        },
+        {
+          anonymous: false,
+          inputs: [
+            {
               indexed: true,
               internalType: "bytes32",
               name: "_requestId",
@@ -93,6 +142,31 @@ const deployedContracts = {
             },
           ],
           name: "ValidationRequested",
+          type: "event",
+        },
+        {
+          anonymous: false,
+          inputs: [
+            {
+              indexed: true,
+              internalType: "bytes32",
+              name: "_requestId",
+              type: "bytes32",
+            },
+            {
+              indexed: true,
+              internalType: "bytes32",
+              name: "_contentItemHash",
+              type: "bytes32",
+            },
+            {
+              indexed: false,
+              internalType: "bool",
+              name: "_isContentItemValid",
+              type: "bool",
+            },
+          ],
+          name: "ValidationResponseReceived",
           type: "event",
         },
         {
@@ -114,6 +188,24 @@ const deployedContracts = {
             },
           ],
           name: "extProposeContentItem",
+          outputs: [],
+          stateMutability: "nonpayable",
+          type: "function",
+        },
+        {
+          inputs: [
+            {
+              internalType: "bytes32",
+              name: "_requestId",
+              type: "bytes32",
+            },
+            {
+              internalType: "bool",
+              name: "_isContentItemValid",
+              type: "bool",
+            },
+          ],
+          name: "handleValidationResponse",
           outputs: [],
           stateMutability: "nonpayable",
           type: "function",
@@ -151,8 +243,27 @@ const deployedContracts = {
           type: "function",
         },
         {
+          inputs: [
+            {
+              internalType: "address",
+              name: "",
+              type: "address",
+            },
+          ],
+          name: "points",
+          outputs: [
+            {
+              internalType: "uint256",
+              name: "",
+              type: "uint256",
+            },
+          ],
+          stateMutability: "view",
+          type: "function",
+        },
+        {
           inputs: [],
-          name: "readCounter",
+          name: "proposalReward",
           outputs: [
             {
               internalType: "uint256",
@@ -185,6 +296,45 @@ const deployedContracts = {
         {
           inputs: [
             {
+              internalType: "uint256",
+              name: "_proposalReward",
+              type: "uint256",
+            },
+          ],
+          name: "setProposalReward",
+          outputs: [],
+          stateMutability: "nonpayable",
+          type: "function",
+        },
+        {
+          inputs: [],
+          name: "totalItemsConsumed",
+          outputs: [
+            {
+              internalType: "uint256",
+              name: "",
+              type: "uint256",
+            },
+          ],
+          stateMutability: "view",
+          type: "function",
+        },
+        {
+          inputs: [],
+          name: "totalPoints",
+          outputs: [
+            {
+              internalType: "uint256",
+              name: "",
+              type: "uint256",
+            },
+          ],
+          stateMutability: "view",
+          type: "function",
+        },
+        {
+          inputs: [
+            {
               internalType: "address",
               name: "_user",
               type: "address",
@@ -203,25 +353,6 @@ const deployedContracts = {
           name: "userAction",
           outputs: [],
           stateMutability: "nonpayable",
-          type: "function",
-        },
-        {
-          inputs: [
-            {
-              internalType: "address",
-              name: "",
-              type: "address",
-            },
-          ],
-          name: "userReadCounter",
-          outputs: [
-            {
-              internalType: "uint256",
-              name: "",
-              type: "uint256",
-            },
-          ],
-          stateMutability: "view",
           type: "function",
         },
       ],

--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -20,19 +20,24 @@ import { useScaffoldContractRead } from "~~/hooks/scaffold-eth/useScaffoldContra
 
 // Creating a functional component for the homepage
 const Home: NextPage = () => {
+  const pointsUIMultiplier = 10; // Multiplier to convert points to UI units
   // State management hooks to store different pieces of information
   const { address } = useAccount(); // Retrieves the current user's blockchain address
   const contractName = "YourContract"; // Name of the smart contract to interact with
   // Hooks to read data from the deployed contract using its name
   const { data: deployedContractData } = useDeployedContractInfo(contractName);
-  const { data: totalReadCount } = useScaffoldContractRead({
+  const { data: totalPoints } = useScaffoldContractRead({
     contractName: contractName,
-    functionName: "readCounter",
+    functionName: "totalPoints",
+  });
+  const { data: totalItemsConsumed } = useScaffoldContractRead({
+    contractName: contractName,
+    functionName: "totalItemsConsumed",
   });
 
-  const { data: userReadCount } = useScaffoldContractRead({
+  const { data: totalUserPoints } = useScaffoldContractRead({
     contractName: contractName,
-    functionName: "userReadCounter",
+    functionName: "points",
     args: [address],
   });
 
@@ -355,25 +360,23 @@ const Home: NextPage = () => {
         )}
       </div>
       <div className="flex items-center flex-col flex-grow pt=10 my-10">
-        <h2>Total Reads</h2>
-        {/* </div>
-      <div className="flex items-center flex-col flex-grow pt=10"> */}
-        <div className="p-4 text-4xl">{totalReadCount?.toString()}</div>
+        <h2>🤓 Total Items Consumed 📚</h2>
+        <div className="p-4 text-4xl">{totalItemsConsumed?.toString()}</div>
       </div>
       <div className="flex items-center flex-col flex-grow pt=10 my-10">
-        <h2>Your Count</h2>
-        {/* </div>
-      <div className="flex items-center flex-col flex-grow pt=10"> */}
+        <h2>Total Points</h2>
+        <div className="p-4 text-4xl">{Number(totalPoints) * pointsUIMultiplier}</div>
+      </div>
+      <div className="flex items-center flex-col flex-grow pt=10 my-10">
+        <h2>Your Points</h2>
         <Address address={address} />
-        <div className="p-4 text-4xl">{userReadCount?.toString()}</div>
+        <div className="p-4 text-4xl">{Number(totalUserPoints) * pointsUIMultiplier}</div>
       </div>
       <></>
       {/* Form for proposing a new content item */}
       <div className="flex items-center flex-col flex-grow pt=10 my-10">
         <h2>Propose</h2>
         <p>Propose financial literacy and well-being content to earn rewards!</p>
-        {/* </div>
-      <div className="flex items-center flex-col flex-grow pt=10"> */}
         <form onSubmit={handleUrlSubmit} className="flex flex-col items-center">
           <InputBase
             name="url"


### PR DESCRIPTION
This PR adds the ability to propose content from the front end. Unlike with consuming content, the user **does sign and send the proposal transaction** and so needs to have gas to pay for the transaction.

It makes several name changes and introduces a number of new events and public state variables.

To keep things "simple," I'm taking the approach that the smart contract does not need to keep track of content items beyond their proposal, validation, and consumption. That information is sent to the smart contract so that the information can be stored on-chain via events. So, one cannot call the smart contract to learn _which content items_ a user (address) has consumed, only that the user has a certain number of points. But an off-chain system is able to review the blockchain history and reconstruct which content items have been proposed and consumed by which address.